### PR TITLE
Add a way to handle interaction with URLs

### DIFF
--- a/Playgrounds/AttributedText_iOS.playground/Contents.swift
+++ b/Playgrounds/AttributedText_iOS.playground/Contents.swift
@@ -27,9 +27,16 @@ struct ContentView: View {
     }()
 
     var body: some View {
-        AttributedText(attributedString)
-            .background(Color.gray.opacity(0.5))
-            .accentColor(.purple)
+        Group {
+            AttributedText(attributedString)
+            AttributedText(attributedString) { url, interaction in
+                print("Interacted with \(url)")
+                // Allow performing default action
+                return true
+            }
+        }
+        .background(Color.gray.opacity(0.5))
+        .accentColor(.purple)
     }
 }
 

--- a/Playgrounds/AttributedText_macOS.playground/Contents.swift
+++ b/Playgrounds/AttributedText_macOS.playground/Contents.swift
@@ -27,9 +27,16 @@ struct ContentView: View {
     }()
 
     var body: some View {
-        AttributedText(attributedString)
-            .background(Color.gray.opacity(0.5))
-            .accentColor(.purple)
+        Group {
+            AttributedText(attributedString)
+            AttributedText(attributedString) { link in
+                print("Clicked \(link)")
+                // Do not mark click as handled -> perform default action
+                return false
+            }
+        }
+        .background(Color.gray.opacity(0.5))
+        .accentColor(.purple)
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,16 @@ struct ContentView: View {
     }()
 
     var body: some View {
-        AttributedText(attributedString)
-            .background(Color.gray.opacity(0.5))
-            .accentColor(.purple)
+        Group {
+            AttributedText(attributedString)
+            AttributedText(attributedString) { url, interaction in
+                print("Interacted with \(url)")
+                // Allow performing default action
+                return true
+            }
+        }
+        .background(Color.gray.opacity(0.5))
+        .accentColor(.purple)
     }
 }
 ```

--- a/Sources/AttributedText/AttributedText.swift
+++ b/Sources/AttributedText/AttributedText.swift
@@ -4,12 +4,36 @@
 
     @available(macOS 11.0, iOS 14.0, tvOS 14.0, *)
     public struct AttributedText: View {
+
+        #if os(macOS)
+        /// Handles the click on the link.
+        ///
+        /// - Parameters:
+        ///     - link: The link that was clicked.
+        /// - Returns: `true` if the click was handled; otherwise, `false` to allow the next responder to handle it.
+        public typealias OpenURLAction = (_ link: URL) -> Bool
+        #else
+        /// Handles interaction with the specified URL.
+        ///
+        /// You can return `true` from this closure to allow the system to perform default actions
+        /// such as opening URL in user's browser or presenting list of actions. If you return `false`
+        /// no additional actions will be performed.
+        ///
+        /// - Parameters:
+        ///     - URL: The URL to be processed.
+        ///     - interaction: The type of interaction that is occurring.
+        /// - Returns: `true` if interaction with the URL should be allowed; `false` if interaction should not be allowed.
+        public typealias OpenURLAction = (_ URL: URL, _ interaction: UITextItemInteraction) -> Bool
+        #endif
+
         @StateObject private var textViewStore = TextViewStore()
 
         private let attributedText: NSAttributedString
+        private let openURL: OpenURLAction?
 
-        public init(_ attributedText: NSAttributedString) {
+        public init(_ attributedText: NSAttributedString, openURL: OpenURLAction? = nil) {
             self.attributedText = attributedText
+            self.openURL = openURL
         }
 
         public var body: some View {
@@ -17,7 +41,8 @@
                 TextViewWrapper(
                     attributedText: attributedText,
                     maxLayoutWidth: geometry.maxWidth,
-                    textViewStore: textViewStore
+                    textViewStore: textViewStore,
+                    openURL: openURL
                 )
             }
             .frame(

--- a/Sources/AttributedText/TextViewWrapper+NSTextView.swift
+++ b/Sources/AttributedText/TextViewWrapper+NSTextView.swift
@@ -29,12 +29,16 @@
 
         final class Coordinator: NSObject, NSTextViewDelegate {
             var openURL: OpenURLAction?
+            var customOpenURL: AttributedText.OpenURLAction?
 
             func textView(_: NSTextView, clickedOnLink link: Any, at _: Int) -> Bool {
                 guard let url = (link as? URL) ?? (link as? String).flatMap(URL.init(string:)) else {
                     return false
                 }
 
+                if let customOpenURL = customOpenURL {
+                    return customOpenURL(url)
+                }
                 openURL?(url)
                 return false
             }
@@ -43,6 +47,7 @@
         let attributedText: NSAttributedString
         let maxLayoutWidth: CGFloat
         let textViewStore: TextViewStore
+        let openURL: AttributedText.OpenURLAction?
 
         func makeNSView(context: Context) -> View {
             let nsView = View(frame: .zero)
@@ -67,6 +72,7 @@
             nsView.textContainer?.lineBreakMode = NSLineBreakMode(truncationMode: context.environment.truncationMode)
 
             context.coordinator.openURL = context.environment.openURL
+            context.coordinator.customOpenURL = openURL
 
             textViewStore.didUpdateTextView(nsView)
         }

--- a/Sources/AttributedText/TextViewWrapper+UITextView.swift
+++ b/Sources/AttributedText/TextViewWrapper+UITextView.swift
@@ -25,8 +25,12 @@
 
         final class Coordinator: NSObject, UITextViewDelegate {
             var openURL: OpenURLAction?
+            var customOpenURL: AttributedText.OpenURLAction?
 
-            func textView(_: UITextView, shouldInteractWith URL: URL, in _: NSRange, interaction _: UITextItemInteraction) -> Bool {
+            func textView(_: UITextView, shouldInteractWith URL: URL, in _: NSRange, interaction: UITextItemInteraction) -> Bool {
+                if let customOpenURL = customOpenURL {
+                    return customOpenURL(URL, interaction)
+                }
                 openURL?(URL)
                 return false
             }
@@ -35,6 +39,7 @@
         let attributedText: NSAttributedString
         let maxLayoutWidth: CGFloat
         let textViewStore: TextViewStore
+        let openURL: AttributedText.OpenURLAction?
 
         func makeUIView(context: Context) -> View {
             let uiView = View()
@@ -59,6 +64,7 @@
             uiView.textContainer.lineBreakMode = NSLineBreakMode(truncationMode: context.environment.truncationMode)
 
             context.coordinator.openURL = context.environment.openURL
+            context.coordinator.customOpenURL = openURL
 
             textViewStore.didUpdateTextView(uiView)
         }


### PR DESCRIPTION
# Description

This pull request introduces possibility to override default behavior when interacting with URLs located inside of `NSAttributedString`. My use case is that I want to handle URLs in a specific way instead of always redirecting the user to browser. Additionally I want to distinguish between tap and long tap interactions on these links. This pull request makes all of that possible.

# Implementation

The feature is implemented by addition of optional `openURL` parameter. If developers do not specify it `AttributedText` component will behave like previously. If developers pass that block, they can run custom code each time users interact with URLs.

The meaning of return value from `openURL` parameter varies between platform and has been documented accordingly based on documentation from `func textView(_: UITextView, shouldInteractWith URL: URL, in _: NSRange, interaction: UITextItemInteraction) -> Bool` and `func textView(_: NSTextView, clickedOnLink link: Any, at _: Int) -> Bool` functions.

I didn't add any new tests as this library only contains snapshot tests, which don't work when wanting to test interaction with links.

# Example

Here by returning true on iOS it's now possible for users to long press on links to show default actions list:

```swift
AttributedText(attributedString) { url, interaction in
    // Allow performing default action
    return true
}
```

![image](https://user-images.githubusercontent.com/5156340/113480470-a9d03f80-9494-11eb-9b7a-fb22f6c6318e.png)
