### PR TITLE
Added access to linkTextAttributes

### DIFF
--- a/Sources/AttributedText/AttributedText.swift
+++ b/Sources/AttributedText/AttributedText.swift
@@ -48,3 +48,30 @@ extension GeometryProxy {
     size.width - safeAreaInsets.leading - safeAreaInsets.trailing
   }
 }
+
+extension View {
+  /// Set the attributes used to draw the onscreen presentation of link text.
+  /// - Parameter linkTextAttributes: The attributes used to draw the onscreen presentation of link text.
+  /// - Returns: A view with the linkTextAttributes set to the value you supply.
+  public func linkTextAttributes(_ linkTextAttributes: [NSAttributedString.Key: Any]) -> some View {
+    environment(\.linkTextAttributes, linkTextAttributes)
+  }
+
+  /// Set the attributes used to draw the onscreen presentation of link text.
+  /// - Parameter linkTextAttributes: A closure that creates the attributes used to draw the onscreen presentation of link text.
+  /// - Returns: A view with the linkTextAttributes set to the value you supply.
+  public func linkTextAttributes(_ linkTextAttributes: () -> [NSAttributedString.Key: Any]) -> some View {
+    environment(\.linkTextAttributes, linkTextAttributes())
+  }
+}
+
+extension EnvironmentValues {
+  internal var linkTextAttributes: [NSAttributedString.Key: Any]? {
+    get { self[LinkTextAttributesKey.self] }
+    set { self[LinkTextAttributesKey.self] = newValue }
+  }
+}
+
+private struct LinkTextAttributesKey: EnvironmentKey {
+  static let defaultValue: [NSAttributedString.Key: Any]? = nil
+}

--- a/Sources/AttributedText/AttributedTextImpl+iOS.swift
+++ b/Sources/AttributedText/AttributedTextImpl+iOS.swift
@@ -10,6 +10,10 @@
       uiView.attributedText = attributedText
       uiView.maxLayoutWidth = maxLayoutWidth
 
+      if let linkTextAttributes = context.environment.linkTextAttributes {
+        uiView.linkTextAttributes = linkTextAttributes
+      }
+
       uiView.textContainer.maximumNumberOfLines = context.environment.lineLimit ?? 0
       uiView.textContainer.lineBreakMode = NSLineBreakMode(
         truncationMode: context.environment.truncationMode

--- a/Sources/AttributedText/AttributedTextImpl+macOS.swift
+++ b/Sources/AttributedText/AttributedTextImpl+macOS.swift
@@ -21,6 +21,10 @@
       nsView.textStorage?.setAttributedString(attributedText)
       nsView.maxLayoutWidth = maxLayoutWidth
 
+      if let linkTextAttributes = context.environment.linkTextAttributes {
+        nsView.linkTextAttributes = linkTextAttributes
+      }
+
       nsView.textContainer?.maximumNumberOfLines = context.environment.lineLimit ?? 0
       nsView.textContainer?.lineBreakMode = NSLineBreakMode(
         truncationMode: context.environment.truncationMode

--- a/Sources/AttributedText/AttributedTextImpl+tvOS.swift
+++ b/Sources/AttributedText/AttributedTextImpl+tvOS.swift
@@ -18,6 +18,10 @@
       uiView.attributedText = attributedText
       uiView.maxLayoutWidth = maxLayoutWidth
 
+      if let linkTextAttributes = context.environment.linkTextAttributes {
+        uiView.linkTextAttributes = linkTextAttributes
+      }
+
       uiView.textContainer.maximumNumberOfLines = context.environment.lineLimit ?? 0
       uiView.textContainer.lineBreakMode = NSLineBreakMode(
         truncationMode: context.environment.truncationMode


### PR DESCRIPTION
# Description

A Pull Request to implement a solution for issue https://github.com/gonzalezreal/AttributedText/issues/21.

Created linkTextAttributes environment value. Added linkTextAttributes view modifier. Set the linkTextAttributes in iOS, macOS, and tvOS based on the context environment.

# Implementation

Added `linkTextAttributes` as an internal property of `EnvironmentValues`. This limits access to `linkTextAttributes` to just the AttributedText package. In `AttributedTextImpl.updateUIView`, if `linkTextAttributes` has been set, then set the underlying `TextView`'s `linkTextAttributes` property.

# Examples

There are two ways of setting the linkTextAttributes.

1. Setting with a value
```Swift
AttributedText(…)
  .linkTextAttributes([.foregroundColor: UIColor.black])
```

2. Setting with a closure
```Swift
AttributedText(…)
  .linkTextAttributes {
    [.foregroundColor: UIColor.black]
  }
```

