### PR TITLE
fix: update text size in main thread to avoid thread warning

### DIFF
--- a/Sources/AttributedText/TextSizeViewModel.swift
+++ b/Sources/AttributedText/TextSizeViewModel.swift
@@ -4,6 +4,8 @@ final class TextSizeViewModel: ObservableObject {
   @Published var textSize: CGSize?
 
   func didUpdateTextView(_ textView: AttributedTextImpl.TextView) {
-    textSize = textView.intrinsicContentSize
+    DispatchQueue.main.async { [weak self] in
+      self?.textSize = textView.intrinsicContentSize
+    }
   }
 }


### PR DESCRIPTION
This PR includes the fix for thread warning yelled by Xcode when attempting to update text size outside of main thread.